### PR TITLE
Add support for type parameters of base trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,4 +114,4 @@ task.runAsync // the only side-effecting call
 ```
 
 ### Known issues
-- Only supports liberation of traits of kind `* -> *`
+- There is a possibility of type name collision if base trait contains abstract type named F and it is not last unary type constructor.

--- a/README.md
+++ b/README.md
@@ -119,4 +119,4 @@ task.runAsync // the only side-effecting call
 ```
 
 ### Known issues
-- There is a possibility of type name collision if base trait contains abstract type named F and it is not last unary type constructor.
+- There is a possibility of type name collision if base trait contains abstract type named `F` and it is not last unary type constructor, e.g. `trait Foo[F, A, B[_]]`

--- a/macros/src/main/scala/io/aecor/liberator/FreeAlgebra.scala
+++ b/macros/src/main/scala/io/aecor/liberator/FreeAlgebra.scala
@@ -5,15 +5,14 @@ import cats.~>
 import shapeless.Lazy
 
 /**
-  * Represents the ability to convert some O[F] to natural transformation from some Out to F
+  * Represents the ability to convert F[A] to natural transformation from Out to A
   *
-  * Where Out is called free algebra of O
+  * Out is called a free algebra of F
   *
-  * @tparam O
   */
-trait FreeAlgebra[O[_[_]]] {
+trait FreeAlgebra[F[_[_]]] {
   type Out[_]
-  def apply[F[_]](of: O[F]): Out ~> F
+  def apply[A[_]](of: F[A]): Out ~> A
 }
 
 object FreeAlgebra {

--- a/macros/src/main/scala/io/aecor/liberator/macros/free.scala
+++ b/macros/src/main/scala/io/aecor/liberator/macros/free.scala
@@ -15,76 +15,121 @@ class free extends scala.annotation.StaticAnnotation {
 }
 
 object FreeMacro {
-  def apply(t: Defn.Trait, companion: Option[Defn.Object]): Term.Block = {
-    val typeName = t.name
+  def apply(base: Defn.Trait, companion: Option[Defn.Object]): Term.Block = {
+    val typeName = base.name
     val freeName = s"${typeName.value}Free"
     val freeTypeName = Type.Name(freeName)
-
-    val traitStats = t.templ.stats.get
-
+    val traitStats = base.templ.stats.get
+    val (theF, abstractParams) = (base.tparams.last.name, base.tparams.dropRight(1))
+    val abstractTypes = abstractParams.map(_.name.value).map(Type.Name(_))
     val cases = traitStats.map {
-      case q"def $name[..$tps](..$params): F[$out]" =>
-        q"final case class ${Type.Name(name.value.capitalize)}[..$tps](..$params) extends ${Ctor.Name(freeName)}[$out]"
+      case q"def $name[..$tps](..$params): $theF[$out]" =>
+        q"final case class ${Type.Name(name.value.capitalize)}[..${abstractParams ++ tps}](..$params) extends ${Ctor.Name(freeName)}[..$abstractTypes, $out]"
     }
 
     def caseName(name: Term.Name) = s"$freeName.${name.value.capitalize}"
 
     val methods = traitStats.map {
-      case q"def $name[..$tps](..$params): F[$out]" =>
+      case q"def $name[..$tps](..$params): $theF[$out]" =>
         val ctor = Ctor.Name(caseName(name))
         val args = params.map(_.name.value).map(Term.Name(_))
-        q"def $name[..$tps](..$params): F[$out] = f($ctor(..$args))"
+        q"def $name[..$tps](..$params): $theF[$out] = f($ctor(..$args))"
     }
 
     val patMatCases = traitStats.map {
-      case q"def $methodName[..$tps](..$params): F[$out]" =>
+      case q"def $methodName[..$tps](..$params): $theF[$out]" =>
         val args = params.map(_.name.value).map(Term.Name(_))
         val exractArgs = args.map(Pat.Var.Term(_))
         val ctor = Term.Name(caseName(methodName))
         p"case $ctor(..$exractArgs) => ops.$methodName(..$args)"
     }
 
-    val helperName = Type.fresh("FreeHelper")
+    val freeHelperName = Type.fresh("FreeHelper")
+    val appliedFreeName = Type.fresh(s"Applied$freeTypeName")
+    val appliedBaseName = Type.fresh(s"Applied${typeName.value}")
+    val aParam = q"trait F[A]".tparams.head
+
+
+    implicit class IdOps[A](a: A) {
+      def tap(f: A => Unit): A = {
+        f(a)
+        a
+      }
+    }
+
+    val appliedFreeNameOut =
+      if (abstractTypes.isEmpty) {
+        Type.Name(freeName)
+      } else {
+        t"$appliedFreeName[..$abstractTypes]#Out"
+      }
+
+    val appliedBaseNameOut =
+      if (abstractTypes.isEmpty) {
+        base.name
+      } else {
+        t"$appliedBaseName[..$abstractTypes]#Out"
+      }
 
     val companionStats: Seq[Stat] = Seq(
-      q"def apply[F[_]](implicit instance: $typeName[F]): $typeName[F] = instance",
-      q"sealed abstract class $freeTypeName[A] extends Product with Serializable",
+      {
+        val types = base.tparams.map(x => Type.Name(x.name.value))
+        q"def apply[..${base.tparams}](implicit instance: $typeName[..$types]): $typeName[..$types] = instance"
+      },
+      q"sealed abstract class $freeTypeName[..$abstractParams, A] extends Product with Serializable",
       q"""object ${Term.Name(freeName)} {
         ..$cases
       }
-      """
-      ,q"""def fromFunctionK[F[_]](f: _root_.cats.arrow.FunctionK[$freeTypeName, F]): $typeName[F] =
-         new ${Ctor.Name(typeName.value)}[F] {
+      """,
+        q"""
+         type $appliedFreeName[..$abstractParams] = {
+            type Out[A] = $freeTypeName[..$abstractTypes, A]
+         }
+       """.tap(println)
+      ,
+        q"""def fromFunctionK[..$abstractParams, F[_]](f: _root_.cats.arrow.FunctionK[$appliedFreeNameOut, F]): $typeName[..$abstractTypes, F] =
+         new ${Ctor.Name(typeName.value)}[..$abstractTypes, F] {
           ..$methods
           }
        """
     ,
-      q"""def toFunctionK[F[_]](ops: $typeName[F]): _root_.cats.arrow.FunctionK[$freeTypeName, F] =
-         new _root_.cats.arrow.FunctionK[$freeTypeName, F] {
-          def apply[A](op: $freeTypeName[A]): F[A] =
+        q"""def toFunctionK[..$abstractParams, F[_]](ops: $typeName[..$abstractTypes, F]): _root_.cats.arrow.FunctionK[$appliedFreeNameOut, F] =
+         new _root_.cats.arrow.FunctionK[$appliedFreeNameOut, F] {
+          def apply[A](op: $freeTypeName[..$abstractTypes, A]): F[A] =
             op match { ..case $patMatCases }
          }
        """
       ,
         q"""
-           type $helperName[F[_]] = {
+           type $freeHelperName[F[_]] = {
              type Out[A] = _root_.cats.free.Free[F, A]
            }
          """
     ,
-    q"""
-       implicit def freeInstance[F[_]](implicit inject: _root_.cats.free.Inject[$freeTypeName, F]): $typeName[$helperName[F]#Out] =
-         fromFunctionK(new _root_.cats.arrow.FunctionK[$freeTypeName, $helperName[F]#Out] {
-          def apply[A](op: $freeTypeName[A]): _root_.cats.free.Free[F, A] = _root_.cats.free.Free.inject(op)
+
+      q"""
+       implicit def freeInstance[..$abstractParams, F[_]](implicit inject: _root_.cats.free.Inject[$appliedFreeNameOut, F]): $typeName[..$abstractTypes, $freeHelperName[F]#Out] =
+         fromFunctionK(new _root_.cats.arrow.FunctionK[$appliedFreeNameOut, $freeHelperName[F]#Out] {
+          def apply[A](op: $freeTypeName[..$abstractTypes, A]): _root_.cats.free.Free[F, A] = _root_.cats.free.Free.inject(op)
          })
-     """,
-    q"""
-        implicit val freeAlgebra: io.aecor.liberator.FreeAlgebra.Aux[$typeName, $freeTypeName] =
-          new io.aecor.liberator.FreeAlgebra[$typeName] {
-            type Out[A] = $freeTypeName[A]
-            override def apply[F[_]](of: $typeName[F]): _root_.cats.arrow.FunctionK[$freeTypeName, F] = ${Term.Name(typeName.value)}.toFunctionK(of)
+     """
+    ,
+
+        q"""
+           type $appliedBaseName[..$abstractParams] = {
+             type Out[F[_]] = $typeName[..$abstractTypes, F]
+           }
+         """,
+
+      q"""
+        implicit def liberatorFreeAlgebra[..$abstractParams]: io.aecor.liberator.FreeAlgebra.Aux[$appliedBaseNameOut, $appliedFreeNameOut] =
+          new io.aecor.liberator.FreeAlgebra[$appliedBaseNameOut] {
+            type Out[A] = $freeTypeName[..$abstractTypes, A]
+            override def apply[F[_]](of: $typeName[..$abstractTypes, F]): _root_.cats.arrow.FunctionK[$appliedFreeNameOut, F] = ${Term.Name(typeName.value)}.toFunctionK(of)
           }
     """)
+
+
 
 
     val newCompanion = companion match {
@@ -92,11 +137,13 @@ object FreeMacro {
         val oldTemplStats = c.templ.stats.getOrElse(Nil)
           c.copy(templ = c.templ.copy(stats = Some(companionStats ++ oldTemplStats)))
       case None =>
-        q"object ${Term.Name(t.name.value)} { ..$companionStats }"
+        q"object ${Term.Name(typeName.value)} { ..$companionStats }"
 
     }
 
-    Term.Block(Seq(t, newCompanion))
+    println(newCompanion)
+
+    Term.Block(Seq(base, newCompanion))
   }
 }
 


### PR DESCRIPTION
This PR adds support for interfaces with multiple type parameters, e.g.

```scala
trait KeyValueStore[K, V, F[_]] {
  def setValue(key: K, value: V): F[Unit]
  def getValue(key: K): F[Option[V]]
}
```

Fixes #4 and #6 
