### PR TITLE
Fix name collision if higher order type has name different from "F" #7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,14 @@ lazy val macros =
   )
 
 lazy val tests =
-  project.settings(name := "tests", commonSettings, noPublishSettings).dependsOn(macros)
+  project
+    .settings(
+      name := "tests",
+      commonSettings,
+      noPublishSettings,
+      libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.0.0")
+    )
+    .dependsOn(macros)
 
 lazy val noPublishSettings = Seq(publish := (), publishLocal := (), publishArtifact := false)
 

--- a/macros/src/main/scala/io/aecor/liberator/macros/free.scala
+++ b/macros/src/main/scala/io/aecor/liberator/macros/free.scala
@@ -15,12 +15,20 @@ class free extends scala.annotation.StaticAnnotation {
 }
 
 object FreeMacro {
+
+  def findLastHigherOrderTypeParam(params: Seq[Type.Param]): (Type.Param, Seq[Type.Param]) = {
+    val lastHigherOrderType = params.filter(_.tparams.length == 1).last
+    lastHigherOrderType -> params.filterNot(_ == lastHigherOrderType)
+  }
+
   def apply(base: Defn.Trait, companion: Option[Defn.Object]): Term.Block = {
     val typeName = base.name
     val freeName = s"${typeName.value}Free"
     val freeTypeName = Type.Name(freeName)
     val traitStats = base.templ.stats.get
-    val (theF, abstractParams) = (base.tparams.last.name, base.tparams.dropRight(1))
+    val (theFType, abstractParams) = findLastHigherOrderTypeParam(base.tparams)
+    val theFName = theFType.name.value
+    val typeNameAsTheF = Type.Name(theFName)
     val abstractTypes = abstractParams.map(_.name.value).map(Type.Name(_))
 
     def caseName(name: Term.Name) = s"$freeName.${name.value.capitalize}"
@@ -46,7 +54,7 @@ object FreeMacro {
 
 
     val abstractMethods = traitStats.map {
-      case m @ q"def $name[..$tps](..$params): ${someF: Type.Name}[$out]" if someF.value == theF.value =>
+      case m @ q"def $name[..$tps](..$params): ${someF: Type.Name}[$out]" if someF.value == theFName =>
         m
     }
 
@@ -74,10 +82,10 @@ object FreeMacro {
           case q"def $name[..$tps](..$params): $_[$out]" =>
             val ctor = Ctor.Name(caseName(name))
             val args = params.map(_.name.value).map(Term.Name(_))
-            q"def $name[..$tps](..$params): F[$out] = f($ctor(..$args))"
+            q"def $name[..$tps](..$params): $typeNameAsTheF[$out] = f($ctor(..$args))"
         }
-        q"""def fromFunctionK[..$abstractParams, F[_]](f: _root_.cats.arrow.FunctionK[$appliedFreeNameOut, F]): $typeName[..$abstractTypes, F] =
-         new ${Ctor.Name(typeName.value)}[..$abstractTypes, F] {
+        q"""def fromFunctionK[..$abstractParams, $theFType](f: _root_.cats.arrow.FunctionK[$appliedFreeNameOut, $typeNameAsTheF]): $typeName[..$abstractTypes, $typeNameAsTheF] =
+         new ${Ctor.Name(typeName.value)}[..$abstractTypes, $typeNameAsTheF] {
           ..$methods
           }
        """
@@ -89,34 +97,34 @@ object FreeMacro {
             val ctor = Term.Name(caseName(methodName))
             p"case $ctor(..$exractArgs) => ops.$methodName(..$args)"
         }
-        q"""def toFunctionK[..$abstractParams, F[_]](ops: $typeName[..$abstractTypes, F]): _root_.cats.arrow.FunctionK[$appliedFreeNameOut, F] =
-         new _root_.cats.arrow.FunctionK[$appliedFreeNameOut, F] {
-          def apply[A](op: $freeTypeName[..$abstractTypes, A]): F[A] =
+        q"""def toFunctionK[..$abstractParams, $theFType](ops: $typeName[..$abstractTypes, $typeNameAsTheF]): _root_.cats.arrow.FunctionK[$appliedFreeNameOut, $typeNameAsTheF] =
+         new _root_.cats.arrow.FunctionK[$appliedFreeNameOut, $typeNameAsTheF] {
+          def apply[A](op: $freeTypeName[..$abstractTypes, A]): $typeNameAsTheF[A] =
             op match { ..case $cases }
          }
        """
       },
       q"""
-           type $freeHelperName[F[_]] = {
-             type Out[A] = _root_.cats.free.Free[F, A]
+           type $freeHelperName[$theFType] = {
+             type Out[A] = _root_.cats.free.Free[$typeNameAsTheF, A]
            }
          """,
       q"""
-       implicit def freeInstance[..$abstractParams, F[_]](implicit inject: _root_.cats.free.Inject[$appliedFreeNameOut, F]): $typeName[..$abstractTypes, $freeHelperName[F]#Out] =
-         fromFunctionK(new _root_.cats.arrow.FunctionK[$appliedFreeNameOut, $freeHelperName[F]#Out] {
-          def apply[A](op: $freeTypeName[..$abstractTypes, A]): _root_.cats.free.Free[F, A] = _root_.cats.free.Free.inject(op)
+       implicit def freeInstance[..$abstractParams, $theFType](implicit inject: _root_.cats.free.Inject[$appliedFreeNameOut, $typeNameAsTheF]): $typeName[..$abstractTypes, $freeHelperName[$typeNameAsTheF]#Out] =
+         fromFunctionK(new _root_.cats.arrow.FunctionK[$appliedFreeNameOut, $freeHelperName[$typeNameAsTheF]#Out] {
+          def apply[A](op: $freeTypeName[..$abstractTypes, A]): _root_.cats.free.Free[$typeNameAsTheF, A] = _root_.cats.free.Free.inject(op)
          })
      """,
       q"""
            type $appliedBaseName[..$abstractParams] = {
-             type Out[F[_]] = $typeName[..$abstractTypes, F]
+             type Out[$theFType] = $typeName[..$abstractTypes, $typeNameAsTheF]
            }
          """,
       q"""
         implicit def liberatorFreeAlgebra[..$abstractParams]: io.aecor.liberator.FreeAlgebra.Aux[$appliedBaseNameOut, $appliedFreeNameOut] =
           new io.aecor.liberator.FreeAlgebra[$appliedBaseNameOut] {
             type Out[A] = $freeTypeName[..$abstractTypes, A]
-            override def apply[F[_]](of: $typeName[..$abstractTypes, F]): _root_.cats.arrow.FunctionK[$appliedFreeNameOut, F] = ${Term
+            override def apply[$theFType](of: $typeName[..$abstractTypes, $typeNameAsTheF]): _root_.cats.arrow.FunctionK[$appliedFreeNameOut, $typeNameAsTheF] = ${Term
         .Name(typeName.value)}.toFunctionK(of)
           }
     """

--- a/tests/src/main/scala/io/aecor/liberator/tests/FreeMacroSpec1.scala
+++ b/tests/src/main/scala/io/aecor/liberator/tests/FreeMacroSpec1.scala
@@ -48,4 +48,17 @@ class FreeMacroSpec1 extends FlatSpec with Matchers {
     FreeMacro(defn, None).toString() shouldEqual block.toString()
   }
 
+  it should "fail assertion if the rightmost type is not a higher order one" in {
+    val defn =
+      source"""
+        trait KVS[K, F[_], V] {
+            def getValue(key: K): F[Option[V]]
+          }
+      """.collect {
+        case t: Defn.Trait => t
+      }.head
+
+    an[AssertionError] should be thrownBy FreeMacro(defn, None)
+  }
+
 }

--- a/tests/src/main/scala/io/aecor/liberator/tests/FreeMacroSpec1.scala
+++ b/tests/src/main/scala/io/aecor/liberator/tests/FreeMacroSpec1.scala
@@ -1,0 +1,51 @@
+package io.aecor.liberator.tests
+
+import io.aecor.liberator.macros.FreeMacro
+import org.scalatest.{ FlatSpec, Matchers }
+
+import scala.meta._
+
+class FreeMacroSpec1 extends FlatSpec with Matchers {
+
+  "Free macro" should "generate boilerplate" in {
+
+    val defn =
+      source"""
+        trait KVS[K, V, F[_]] {
+            def getValue(key: K): F[Option[V]]
+          }
+      """.collect {
+        case t: Defn.Trait => t
+      }.head
+
+    val block = Term.Block(
+      """
+        |  trait KVS[K, V, F[_]] {
+        |    def getValue(key: K): F[Option[V]]
+        |  }
+        |  object KVS {
+        |    def apply[K, V, F[_]](implicit instance: KVS[K, V, F]): KVS[K, V, F] = instance
+        |    sealed abstract class KVSFree[K, V, A] extends Product with Serializable
+        |    object KVSFree { final case class GetValue[K, V](key: K) extends KVSFree[K, V, Option[V]] }
+        |    type AppliedKVSFree2[K, V] = { type Out[A] = KVSFree[K, V, A] }
+        |    def fromFunctionK[K, V, F[_]](f: _root_.cats.arrow.FunctionK[AppliedKVSFree2[K, V]#Out, F]): KVS[K, V, F] = new KVS[K, V, F] { def getValue(key: K): F[Option[V]] = f(KVSFree.GetValue(key)) }
+        |    def toFunctionK[K, V, F[_]](ops: KVS[K, V, F]): _root_.cats.arrow.FunctionK[AppliedKVSFree2[K, V]#Out, F] = new _root_.cats.arrow.FunctionK[AppliedKVSFree2[K, V]#Out, F] {
+        |      def apply[A](op: KVSFree[K, V, A]): F[A] = op match {
+        |        case KVSFree.GetValue(key) => ops.getValue(key)
+        |      }
+        |    }
+        |    type FreeHelper1[F[_]] = { type Out[A] = _root_.cats.free.Free[F, A] }
+        |    implicit def freeInstance[K, V, F[_]](implicit inject: _root_.cats.free.Inject[AppliedKVSFree2[K, V]#Out, F]): KVS[K, V, FreeHelper1[F]#Out] = fromFunctionK(new _root_.cats.arrow.FunctionK[AppliedKVSFree2[K, V]#Out, FreeHelper1[F]#Out] { def apply[A](op: KVSFree[K, V, A]): _root_.cats.free.Free[F, A] = _root_.cats.free.Free.inject(op) })
+        |    type AppliedKVS3[K, V] = { type Out[F[_]] = KVS[K, V, F] }
+        |    implicit def liberatorFreeAlgebra[K, V]: io.aecor.liberator.FreeAlgebra.Aux[AppliedKVS3[K, V]#Out, AppliedKVSFree2[K, V]#Out] = new io.aecor.liberator.FreeAlgebra[AppliedKVS3[K, V]#Out] {
+        |      type Out[A] = KVSFree[K, V, A]
+        |      override def apply[F[_]](of: KVS[K, V, F]): _root_.cats.arrow.FunctionK[AppliedKVSFree2[K, V]#Out, F] = KVS.toFunctionK(of)
+        |    }
+        |  }
+      """.stripMargin.parse[Source].get.stats
+    )
+
+    FreeMacro(defn, None).toString() shouldEqual block.toString()
+  }
+
+}

--- a/tests/src/main/scala/io/aecor/liberator/tests/FreeMacroSpec2.scala
+++ b/tests/src/main/scala/io/aecor/liberator/tests/FreeMacroSpec2.scala
@@ -1,0 +1,51 @@
+package io.aecor.liberator.tests
+
+import io.aecor.liberator.macros.FreeMacro
+import org.scalatest.{ FlatSpec, Matchers }
+
+import scala.meta._
+
+class FreeMacroSpec2 extends FlatSpec with Matchers {
+
+  "Free macro" should "use higher order type name from trait definition to avoid name collision" in {
+
+    val defn =
+      source"""
+        trait KVS[K, V, Higher[_]] {
+            def getValue(key: K): Higher[Option[V]]
+          }
+      """.collect {
+        case t: Defn.Trait => t
+      }.head
+
+    val block = Term.Block(
+      """
+        |  trait KVS[K, V, Higher[_]] {
+        |    def getValue(key: K): Higher[Option[V]]
+        |  }
+        |  object KVS {
+        |    def apply[K, V, Higher[_]](implicit instance: KVS[K, V, Higher]): KVS[K, V, Higher] = instance
+        |    sealed abstract class KVSFree[K, V, A] extends Product with Serializable
+        |    object KVSFree { final case class GetValue[K, V](key: K) extends KVSFree[K, V, Option[V]] }
+        |    type AppliedKVSFree2[K, V] = { type Out[A] = KVSFree[K, V, A] }
+        |    def fromFunctionK[K, V, Higher[_]](f: _root_.cats.arrow.FunctionK[AppliedKVSFree2[K, V]#Out, Higher]): KVS[K, V, Higher] = new KVS[K, V, Higher] { def getValue(key: K): Higher[Option[V]] = f(KVSFree.GetValue(key)) }
+        |    def toFunctionK[K, V, Higher[_]](ops: KVS[K, V, Higher]): _root_.cats.arrow.FunctionK[AppliedKVSFree2[K, V]#Out, Higher] = new _root_.cats.arrow.FunctionK[AppliedKVSFree2[K, V]#Out, Higher] {
+        |      def apply[A](op: KVSFree[K, V, A]): Higher[A] = op match {
+        |        case KVSFree.GetValue(key) => ops.getValue(key)
+        |      }
+        |    }
+        |    type FreeHelper1[Higher[_]] = { type Out[A] = _root_.cats.free.Free[Higher, A] }
+        |    implicit def freeInstance[K, V, Higher[_]](implicit inject: _root_.cats.free.Inject[AppliedKVSFree2[K, V]#Out, Higher]): KVS[K, V, FreeHelper1[Higher]#Out] = fromFunctionK(new _root_.cats.arrow.FunctionK[AppliedKVSFree2[K, V]#Out, FreeHelper1[Higher]#Out] { def apply[A](op: KVSFree[K, V, A]): _root_.cats.free.Free[Higher, A] = _root_.cats.free.Free.inject(op) })
+        |    type AppliedKVS3[K, V] = { type Out[Higher[_]] = KVS[K, V, Higher] }
+        |    implicit def liberatorFreeAlgebra[K, V]: io.aecor.liberator.FreeAlgebra.Aux[AppliedKVS3[K, V]#Out, AppliedKVSFree2[K, V]#Out] = new io.aecor.liberator.FreeAlgebra[AppliedKVS3[K, V]#Out] {
+        |      type Out[A] = KVSFree[K, V, A]
+        |      override def apply[Higher[_]](of: KVS[K, V, Higher]): _root_.cats.arrow.FunctionK[AppliedKVSFree2[K, V]#Out, Higher] = KVS.toFunctionK(of)
+        |    }
+        |  }
+      """.stripMargin.parse[Source].get.stats
+    )
+
+    FreeMacro(defn, None).toString() shouldEqual block.toString()
+  }
+
+}


### PR DESCRIPTION
This addresses #7 issue by using the same name for `F[_]` as in operations trait definition. Though it could be enhanced further in my opinion: generally `F[_]` may occur in any position, not necessarily as the last type param. For example [cats Kleisli](http://typelevel.org/cats/datatypes/kleisli.html) has its `F[_]` as first param.

Tests're in separate files cause otherwise there's a mess with type names relying on counters (i.e. acquired via `Type.fresh`)